### PR TITLE
Use apb-tools image

### DIFF
--- a/apb_devel/cli_tooling.adoc
+++ b/apb_devel/cli_tooling.adoc
@@ -35,7 +35,7 @@ To run the `apb` tool from a container:
 . Pull the container:
 +
 ----
-$ docker pull docker.io/ansibleplaybookbundle/apb[:<tag>]
+$ docker pull docker.io/ansibleplaybookbundle/apb-tools[:<tag>]
 ----
 +
 There are three tags to choose from:
@@ -51,13 +51,13 @@ There are three tags to choose from:
 .. Create an alias in your *_.bashrc_* or somewhere else for your shell:
 +
 ----
-alias apb='docker run --rm --privileged -v $PWD:/mnt -v $HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $UID docker.io/ansibleplaybookbundle/apb'
+alias apb='docker run --rm --privileged -v $PWD:/mnt -v $HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $UID docker.io/ansibleplaybookbundle/apb-tools'
 ----
 
 .. If you would prefer to use `atomic` rather than an alias:
 +
 ----
-$ atomic run docker.io/ansibleplaybookbundle/apb init my_apb
+$ atomic run docker.io/ansibleplaybookbundle/apb-tools init my_apb
 ----
 
 . Start working by running the command:


### PR DESCRIPTION
Uses the apb-tools image as the apb one is not on docker hub.
Fixes #7496